### PR TITLE
Use mkdirp.sync instead of fs.mkdirSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var path = require('path');
 var async = require('async');
 var File = require('./file').File;
 var Container = require('./container').Container;
+var mkdirp = require('mkdirp');
 
 module.exports.storage = module.exports; // To make it consistent with pkgcloud
 
@@ -70,10 +71,10 @@ function validatePath(targetPath, cb) {
     try {
       var stat = fs.statSync(folderPath);
       if (!stat.isDirectory()) {
-        fs.mkdirSync(folderPath);
+        mkdirp.sync(folderPath);
       }
     } catch(e) {
-      fs.mkdirSync(folderPath); 
+      mkdirp.sync(folderPath);
     }
     var stat = fs.statSync(folderPath);
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.4.2",
+    "mkdirp": "^0.5.1",
     "pkgcloud": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm having issues when the folder I'm trying to save to doesn't exist. `mkdirp` solves the problem for me. Other people might also be having this problem so this might help them as well.
